### PR TITLE
feat: include optional vibration implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,43 @@ class MainActivity : AppCompatActivity() {
 }
 ```
 
+### Per-step completion callback
+
+You can provide an optional `onStepCompleted` callback to react to each liveness step as the user
+completes it — useful for triggering custom sounds, animations, or analytics events:
+
+```kotlin
+LivenessEntryPoint.startLiveness(
+    context = this,
+    onStepCompleted = { step ->
+        // Called after every successful step (e.g. STEP_SMILE, STEP_BLINK…)
+        Log.d("Liveness", "Step completed: $step")
+    }
+) { result ->
+    // final result
+}
+```
+
+### Built-in haptic & sound feedback
+
+Pass `enableVibrationFeedback = true` and/or `enableSoundFeedback = true` inside `CameraSettings` to
+get a short vibration and/or a beep tone automatically after each step is completed:
+
+```kotlin
+LivenessEntryPoint.startLiveness(
+    context = this,
+    cameraSettings = CameraSettings(
+        enableVibrationFeedback = true,
+        enableSoundFeedback = true,
+    )
+) { result ->
+    // final result
+}
+```
+
+> **Note:** Vibration requires the `VIBRATE` permission. The library declares it automatically in
+> its manifest, so no extra setup is needed in your app.
+
 ## Customization
 
 You can customize all the assets and dimensions. It's only required to create the resources with the

--- a/app/src/main/java/com/schaefer/livenessmlkit/MainActivity.kt
+++ b/app/src/main/java/com/schaefer/livenessmlkit/MainActivity.kt
@@ -55,9 +55,15 @@ class MainActivity : AppCompatActivity() {
                     livenessEntryPoint.startLiveness(
                         cameraSettings = CameraSettings(
                             livenessStepList = mutableStepList,
-                            storageType = StorageType.INTERNAL
+                            storageType = StorageType.INTERNAL,
+                            enableVibrationFeedback = binding.switchVibration.isChecked,
+                            enableSoundFeedback = binding.switchSound.isChecked,
                         ),
                         context = this,
+                        onStepCompleted = { step ->
+                            binding.tvLastStep.isVisible = true
+                            binding.tvLastStep.text = getString(R.string.last_step_completed, step.name)
+                        },
                     ) { livenessCameraXResult ->
                         if (livenessCameraXResult.error == null) {
                             val listOfImages = arrayListOf<ByteArray>().apply {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -88,6 +88,19 @@
     </HorizontalScrollView>
 
     <TextView
+        android:id="@+id/tvLastStep"
+        style="@style/TextAppearance.MaterialComponents.Body1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="@+id/tvStepsTitle"
+        app:layout_constraintStart_toStartOf="@+id/tvStepsTitle"
+        app:layout_constraintTop_toBottomOf="@+id/btnStartLiveness"
+        tools:text="Last step: STEP_SMILE"
+        tools:visibility="visible" />
+
+    <TextView
         android:id="@+id/tvListResult"
         style="@style/TextAppearance.MaterialComponents.Headline5"
         android:layout_width="0dp"
@@ -97,7 +110,7 @@
         app:layout_constraintEnd_toEndOf="@+id/tvStepsTitle"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="@+id/tvStepsTitle"
-        app:layout_constraintTop_toBottomOf="@+id/btnStartLiveness" />
+        app:layout_constraintTop_toBottomOf="@+id/tvLastStep" />
 
     <androidx.constraintlayout.widget.Group
         android:id="@+id/groupResultList"
@@ -124,6 +137,36 @@
         tools:listitem="@layout/layout_item_image"
         tools:visibility="visible" />
 
+    <TextView
+        android:id="@+id/tvFeedbackTitle"
+        style="@style/TextAppearance.MaterialComponents.Headline5"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Feedback options"
+        app:layout_constraintEnd_toEndOf="@+id/tvStepsTitle"
+        app:layout_constraintStart_toStartOf="@+id/tvStepsTitle"
+        app:layout_constraintTop_toBottomOf="@+id/horizontalScrollView" />
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/switchVibration"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:text="Vibration feedback"
+        app:layout_constraintEnd_toEndOf="@+id/tvStepsTitle"
+        app:layout_constraintStart_toStartOf="@+id/tvStepsTitle"
+        app:layout_constraintTop_toBottomOf="@+id/tvFeedbackTitle" />
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/switchSound"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="Sound feedback"
+        app:layout_constraintEnd_toEndOf="@+id/tvStepsTitle"
+        app:layout_constraintStart_toStartOf="@+id/tvStepsTitle"
+        app:layout_constraintTop_toBottomOf="@+id/switchVibration" />
+
     <Button
         android:id="@+id/btnStartLiveness"
         android:layout_width="wrap_content"
@@ -132,6 +175,6 @@
         android:text="Start Liveness"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/horizontalScrollView" />
+        app:layout_constraintTop_toBottomOf="@+id/switchSound" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name">Liveness ML Kit</string>
     <string name="result_list">Result of Liveness: %s photos</string>
+    <string name="last_step_completed">Last step completed: %s</string>
 
     <!-- Liveness CameraX Strings-->
     <string name="liveness_camerax_app_name">LivenessCameraX</string>

--- a/livenesscamerax/src/main/AndroidManifest.xml
+++ b/livenesscamerax/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-feature android:name="android.hardware.camera.any" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <application android:name=".CameraXApplication">
         <activity

--- a/livenesscamerax/src/main/java/com/schaefer/livenesscamerax/domain/model/CameraSettings.kt
+++ b/livenesscamerax/src/main/java/com/schaefer/livenesscamerax/domain/model/CameraSettings.kt
@@ -18,7 +18,9 @@ data class CameraSettings(
         StepLiveness.STEP_LUMINOSITY,
         StepLiveness.STEP_SMILE,
         StepLiveness.STEP_BLINK,
-    )
+    ),
+    val enableVibrationFeedback: Boolean = false,
+    val enableSoundFeedback: Boolean = false,
 ) : Parcelable
 
 internal fun CameraSettings.toDomain(): CameraSettingsDomain {

--- a/livenesscamerax/src/main/java/com/schaefer/livenesscamerax/navigation/LivenessEntryPoint.kt
+++ b/livenesscamerax/src/main/java/com/schaefer/livenesscamerax/navigation/LivenessEntryPoint.kt
@@ -6,6 +6,7 @@ import com.schaefer.domain.model.LivenessCameraXResultDomain
 import com.schaefer.livenesscamerax.domain.mapper.toPresentation
 import com.schaefer.livenesscamerax.domain.model.CameraSettings
 import com.schaefer.livenesscamerax.domain.model.LivenessCameraXResult
+import com.schaefer.livenesscamerax.domain.model.StepLiveness
 import com.schaefer.livenesscamerax.presentation.LivenessCameraXActivity
 
 internal const val EXTRAS_LIVENESS_CAMERA_SETTINGS = "liveness_camerax_camera_settings"
@@ -13,10 +14,12 @@ internal const val EXTRAS_LIVENESS_CAMERA_SETTINGS = "liveness_camerax_camera_se
 object LivenessEntryPoint {
 
     var callbackResult: ((LivenessCameraXResult) -> Unit) = {}
+    var onStepCompleted: ((StepLiveness) -> Unit)? = null
 
     fun startLiveness(
         context: Context,
         cameraSettings: CameraSettings = CameraSettings(),
+        onStepCompleted: ((StepLiveness) -> Unit)? = null,
         callback: (LivenessCameraXResult) -> Unit
     ) {
         context.startActivity(
@@ -25,9 +28,14 @@ object LivenessEntryPoint {
             }
         )
         callbackResult = callback
+        LivenessEntryPoint.onStepCompleted = onStepCompleted
     }
 
     internal fun postResultCallback(livenessCameraXResult: LivenessCameraXResultDomain) {
         callbackResult.invoke(livenessCameraXResult.toPresentation())
+    }
+
+    internal fun postStepCompletedCallback(step: StepLiveness) {
+        onStepCompleted?.invoke(step)
     }
 }

--- a/livenesscamerax/src/main/java/com/schaefer/livenesscamerax/presentation/fragment/CameraXFragment.kt
+++ b/livenesscamerax/src/main/java/com/schaefer/livenesscamerax/presentation/fragment/CameraXFragment.kt
@@ -1,11 +1,18 @@
 package com.schaefer.livenesscamerax.presentation.fragment
 
 import android.Manifest
+import android.media.AudioManager
+import android.media.ToneGenerator
+import android.os.Build
 import android.os.Bundle
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -26,12 +33,16 @@ import com.schaefer.livenesscamerax.di.LibraryModule.container
 import com.schaefer.livenesscamerax.domain.model.CameraSettings
 import com.schaefer.livenesscamerax.domain.model.toDomain
 import com.schaefer.livenesscamerax.navigation.EXTRAS_LIVENESS_CAMERA_SETTINGS
+import com.schaefer.livenesscamerax.navigation.LivenessEntryPoint
 import com.schaefer.livenesscamerax.presentation.viewmodel.LivenessViewModel
 import com.schaefer.livenesscamerax.presentation.viewmodel.LivenessViewModelFactory
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.InternalCoroutinesApi
 import timber.log.Timber
+
+private const val VIBRATION_DURATION_MS = 80L
+private const val TONE_DURATION_MS = 100
 
 @FlowPreview
 internal class CameraXFragment : Fragment(R.layout.liveness_camerax_fragment) {
@@ -136,6 +147,38 @@ internal class CameraXFragment : Fragment(R.layout.liveness_camerax_fragment) {
             hasHeadMovedLeft.observeOnce(viewLifecycleOwner) { cameraX.takePicture() }
             hasHeadMovedRight.observeOnce(viewLifecycleOwner) { cameraX.takePicture() }
             hasHeadMovedCenter.observeOnce(viewLifecycleOwner) { cameraX.takePicture() }
+            stepCompleted.observe(viewLifecycleOwner) { step ->
+                LivenessEntryPoint.postStepCompletedCallback(step)
+                if (cameraSettings.enableVibrationFeedback) vibrateOnStepSuccess()
+                if (cameraSettings.enableSoundFeedback) playBeepOnStepSuccess()
+            }
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun vibrateOnStepSuccess() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val manager = ContextCompat.getSystemService(requireContext(), VibratorManager::class.java)
+            manager?.defaultVibrator?.vibrate(
+                VibrationEffect.createOneShot(VIBRATION_DURATION_MS, VibrationEffect.DEFAULT_AMPLITUDE)
+            )
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val vibrator = ContextCompat.getSystemService(requireContext(), Vibrator::class.java)
+            vibrator?.vibrate(
+                VibrationEffect.createOneShot(VIBRATION_DURATION_MS, VibrationEffect.DEFAULT_AMPLITUDE)
+            )
+        } else {
+            val vibrator = ContextCompat.getSystemService(requireContext(), Vibrator::class.java)
+            vibrator?.vibrate(VIBRATION_DURATION_MS)
+        }
+    }
+
+    private fun playBeepOnStepSuccess() {
+        try {
+            val toneGenerator = ToneGenerator(AudioManager.STREAM_NOTIFICATION, ToneGenerator.MAX_VOLUME)
+            toneGenerator.startTone(ToneGenerator.TONE_PROP_BEEP, TONE_DURATION_MS)
+        } catch (e: RuntimeException) {
+            Timber.e(e, "Failed to play step completion sound")
         }
     }
 

--- a/livenesscamerax/src/main/java/com/schaefer/livenesscamerax/presentation/viewmodel/LivenessViewModel.kt
+++ b/livenesscamerax/src/main/java/com/schaefer/livenesscamerax/presentation/viewmodel/LivenessViewModel.kt
@@ -48,6 +48,8 @@ internal class LivenessViewModel(
     val hasHeadMovedRight: LiveData<Boolean> = headMovementRightMutable
     private val headMovementCenterMutable = MutableLiveData<Boolean>()
     val hasHeadMovedCenter: LiveData<Boolean> = headMovementCenterMutable
+    private val stepCompletedMutable = MutableLiveData<StepLiveness>()
+    val stepCompleted: LiveData<StepLiveness> = stepCompletedMutable
 
     fun observeFacesDetection(facesFlowable: Flow<List<FaceResult>>) {
         viewModelScope.launch {
@@ -144,7 +146,7 @@ internal class LivenessViewModel(
         setState(_state.livenessMessage(getMessage()))
     }
     private fun removeCurrentStep() {
-        requestedSteps.pop()
+        stepCompletedMutable.value = requestedSteps.pop()
         setState(_state.livenessMessage(getMessage()))
     }
 


### PR DESCRIPTION
Closes #70
   
   ### Problem
   
   The library only exposed a single callback for the **overall** liveness result. Developers had no way to
   react to each individual step being completed in real time, making it impossible to provide haptic or 
  audio feedback during the flow.
   
   ### Solution
   
   This PR adds three opt-in mechanisms that fire every time a liveness step (smile, blink, head movement, 
  etc.) is successfully completed:
   
   | Mechanism | How to enable |
   |---|---|
   | **Vibration** | `CameraSettings(enableVibrationFeedback = true)` |
   | **Beep sound** | `CameraSettings(enableSoundFeedback = true)` |
   | **Custom callback** | `onStepCompleted = { step -> … }` in `startLiveness()` |
   
   All three are **off by default** — no behaviour change for existing integrations.
   
   ### Changes
   
   - **`CameraSettings`** — two new optional `Boolean` flags: `enableVibrationFeedback` and 
  `enableSoundFeedback`.
   - **`LivenessViewModel`** — new `stepCompleted: LiveData<StepLiveness>` that emits the just-completed 
  step before it is removed from the queue.
   - **`LivenessEntryPoint`** — new optional `onStepCompleted` parameter on `startLiveness()` and an 
  internal `postStepCompletedCallback()` dispatcher.
   - **`CameraXFragment`** — observes `stepCompleted`; triggers the developer callback, vibration 
  (`VibrationEffect`, API-level-aware for S / O / legacy), and/or a `ToneGenerator` beep.
   - **`AndroidManifest`** — declares `VIBRATE` permission (no runtime prompt required).
   - **`README`** — documents all three new options with code examples.
   
   ### Usage example
   
   ```kotlin
   LivenessEntryPoint.startLiveness(
       context = this,
       cameraSettings = CameraSettings(
           enableVibrationFeedback = true,
           enableSoundFeedback = true,
       ),
       onStepCompleted = { step ->
           Log.d("Liveness", "Step completed: $step")
       }
   ) { result ->
       // handle final result
   }
